### PR TITLE
Electron : run as a desktop app

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -8,12 +8,6 @@ var ora = require('ora')
 var webpack = require('webpack')
 var webpackConfig = require('./webpack.prod.conf')
 
-console.log(
-  '  Tip:\n' +
-  '  Built files are meant to be served over an HTTP server.\n' +
-  '  Opening index.html over file:// won\'t work.\n'
-)
-
 var spinner = ora('building for production...')
 spinner.start()
 

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -20,6 +20,7 @@ const webpackConfig = merge(baseWebpackConfig, {
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
     path: config.build.assetsRoot,
+    publicPath: '',
     filename: utils.assetsPath('js/[name].[chunkhash].js'),
     chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,49 @@
+const { app, BrowserWindow } = require('electron')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadURL(`file://${__dirname}/dist/index.html`)
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev": "cross-env NODE_ENV=development node build/dev-server.js",
     "gh": "npm run build && gh-pages -d dist",
     "lint": "eslint --ext .js .vue client/*",
+    "electron": "npm run build && electron electron.js",
     "test": "echo lol"
   },
   "dependencies": {
@@ -80,6 +81,7 @@
     "connect-history-api-fallback": "^1.3.0",
     "cross-env": "^3.1.3",
     "css-loader": "^0.25.0",
+    "electron": "^1.4.1",
     "eslint": "^3.8.0",
     "eslint-config-standard": "^6.1.0",
     "eslint-loader": "^1.6.0",


### PR DESCRIPTION
Here is a PR for issue #12 

You can now run `npm run electron` and get an Electron app launched. Here is what I did :

- Added electron in `package.json`'s `devDependencies`

- Updated Webpack config for the distribution's files to be compatible with Electron (= being served via `file://`)
Note : this also makes it compatible with Cordova, in case you ever want to make a mobile app based on vue-admin
Note 2 : this implies removing the "HTML5 history" router's configuration which has already been done as stated in another issue

- There is still an issue with Font Awesome that is not properly loaded in the distribution version, don't know why... I tried messing around with webpack config but didn't want to lose focus on the electron issue so left it there, you may have some insight to why this doesn't work on my setup ? Does it work on yours ? If you run `npm run build`, you do have the icons right, even when serving the app through `file://` ?
